### PR TITLE
Fixed latin field erased in some conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(schema, config) {
 
     // a simple pre-validate hook to store the latinize copy
     schema.pre('validate', function latinize_validate_hook(next) {
-        this[latin_prop] = _latinize(this[prop]);
+        if (this[prop] !== undefined) this[latin_prop] = _latinize(this[prop]);
         return next();
     });
 


### PR DESCRIPTION
Hello,

I use mongoose-latinize library in some projects and I found a bug that I fixed with this pull request.

The bug was that the latin field could be erased by an empty string when a projection not including the latinized field was done on the mongoose document object used to save some changes.

Here is an example to illustrate the bug.
I use the following simplified collection schema example to illustrate the bug:
```javascript
const schema = mongoose.Schema({
    "name": {type: String, required: true, maxlength: 255},
    "settings": new mongoose.Schema({
        aSetting: {type: String, required: false}, 
    }, { _id: true })
});
schema.plugin(mongoose_latinize, 'name');   // field name is latinized
```
and then the problem occurs when I perform a similar operation:
```javascript
const model = mongooose.connection.model("user", schema);
model.findById("123", "settings").then((oldUser) => {
    if (!oldUser) return null;
    Object.assign(oldUser.settings, {aSetting: "aValue"});
    return oldUser.save();
});
```
As field "name" is not in the projection when requesting the object to update, in the mongoose-latinize function the field latin_name was set to "" (empty string):
```javascript
// code from mongoose-latinize
schema.pre('validate', function latinize_validate_hook(next) {
    this[latin_prop] = _latinize(this[prop]);  // My fix is to add the check if (this[prop] !== undefined) before this code
    return next();
});
```